### PR TITLE
Make game more similar to typemonkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 A terminal based typing game.
 
 Usage:
+```bash
+toggle_cool_cow_says_type [-t {word_count}] [-t {file_extension}] [-s] {project_path}
+```
 
-* `-p`: path to project (required)
+* `-s`: flag to tell the game to run in strict mode
 * `-t`: file extension (defaults to "rs")
 * `-w`: word count (defaults to 10)
 
+Example:
 ```bash
 toggle_cool_cow_says_type -p path_to_project -t c -w 5
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub project_path: PathBuf,
     pub file_extension: String,
     pub word_count: usize,
+    pub strict: bool,
 }
 
 impl Config {
@@ -16,6 +17,7 @@ impl Config {
         let mut file_extension = "rs".to_string();
 
         let mut argc = 0;
+        let mut strict = false;
 
         while let Some(arg) = args.next() {
             argc += 1;
@@ -32,6 +34,9 @@ impl Config {
                     if file_extension.starts_with('.') {
                         file_extension.remove(0);
                     }
+                }
+                "-s" => {
+                    strict = true;
                 }
                 arg => {
                     project_path = Some(arg.to_owned());
@@ -56,6 +61,7 @@ impl Config {
             word_count,
             project_path: project_path.into(),
             file_extension,
+            strict,
         };
 
         Ok(inst)

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,10 +33,9 @@ impl Config {
                         file_extension.remove(0);
                     }
                 }
-                "-p" => {
-                    project_path = args.next();
+                arg => {
+                    project_path = Some(arg.to_owned());
                 }
-                _ => {}
             }
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,8 @@ impl Error {
             Error::ZeroWordCount => "Word count can not be zero".into(),
             Error::NeedsHelp => "Usage: toggle_cool_cow_says_type -t rs -w 5 path_to_project
     -t : extension of files to use for words. Defaults to rs for Rust.
-    -w : number of words to type against. Defaults to 10.".into(),
+    -w : number of words to type against. Defaults to 10.
+    -s : strict mode. Input must be matchedp perfectly, otherwise game can't end!".into(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ impl Error {
             Error::NeedsHelp => "Usage: toggle_cool_cow_says_type -t rs -w 5 path_to_project
     -t : extension of files to use for words. Defaults to rs for Rust.
     -w : number of words to type against. Defaults to 10.
-    -s : strict mode. Input must be matchedp perfectly, otherwise game can't end!".into(),
+    -s : strict mode. Input must be matched perfectly, otherwise game can't end!".into(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,8 +16,7 @@ impl Error {
             Error::NoFiles => "No code files found".into(),
             Error::InsufficientWords => "Not enough words to meet word count".into(),
             Error::ZeroWordCount => "Word count can not be zero".into(),
-            Error::NeedsHelp => "Usage: toggle_cool_cow_says_type -p path_to_project -t rs -w 5
-    -p : path to a code project or word list files. REQUIRED.
+            Error::NeedsHelp => "Usage: toggle_cool_cow_says_type -t rs -w 5 path_to_project
     -t : extension of files to use for words. Defaults to rs for Rust.
     -w : number of words to type against. Defaults to 10.".into(),
         }

--- a/src/gamestate.rs
+++ b/src/gamestate.rs
@@ -20,10 +20,11 @@ pub struct Game {
     mistakes: usize,
     word_count: usize,
     pub state: GameState,
+    strict: bool,
 }
 
 impl Game {
-    pub fn new(words: Vec<String>) -> Self {
+    pub fn new(words: Vec<String>, strict: bool) -> Self {
         let word_count = words.len();
         let text = words.join(" ");
         let text_chars = text.chars().collect::<Vec<_>>();
@@ -35,6 +36,7 @@ impl Game {
             text_chars,
             mistakes: 0,
             state: GameState::Stopped,
+            strict,
         }
     }
 
@@ -91,7 +93,7 @@ impl Game {
             // including the space character itself
             self.input.push(' ');
             self.mistakes += 1;
-            if self.input.len() >= self.text.len() {
+            if !self.strict && self.input.len() >= self.text.len() {
                 self.finish();
             }
             return;
@@ -108,7 +110,7 @@ impl Game {
 
         // if we have mistyped and press space after the last word
         // quit the game
-        let should_quit = self.input.len() > self.text.len() + 1 && a.unwrap_or('.') == ' ';
+        let should_quit = !self.strict && next_index >= self.text.len() + 1 && a.unwrap_or('.') == ' ';
 
         if !should_quit && a != b {
             self.mistakes += 1;
@@ -117,6 +119,10 @@ impl Game {
         // if we input the text correctly or we press space after the last word
         if self.input == self.text || should_quit {
             self.finish();
+        }
+
+        if self.input.len() > self.text.len() {
+            self.input.pop();
         }
     }
 

--- a/src/gamestate.rs
+++ b/src/gamestate.rs
@@ -105,14 +105,13 @@ impl Game {
 
         self.input.push(c);
 
-        let a = self.input.chars().last();
         let b = self.text.chars().take(next_index).last();
 
         // if we have mistyped and press space after the last word
         // quit the game
-        let should_quit = !self.strict && next_index >= self.text.len() + 1 && a.unwrap_or('.') == ' ';
+        let should_quit = !self.strict && next_index >= self.text.len() + 1 && c == ' ';
 
-        if !should_quit && a != b {
+        if !should_quit && Some(c) != b {
             self.mistakes += 1;
         }
 
@@ -167,7 +166,7 @@ mod test {
     #[test]
     fn test_wpm() {
         let words = vec!["one".to_string(), "two".into(), "three".into()];
-        let gs = Game::new(words);
+        let gs = Game::new(words, false);
         let wpm = gs.wpm(Duration::from_secs(60));
         assert_eq!(wpm, 3);
     }
@@ -175,13 +174,13 @@ mod test {
     #[test]
     fn test_word_count() {
         let words = vec!["one".to_string(), "two".into(), "three".into()];
-        let gs = Game::new(words);
+        let gs = Game::new(words, false);
         assert_eq!(gs.word_count, 3);
     }
 
     #[test]
     fn test_mistakes() {
-        let mut gs = Game::new(vec!["one".into()]);
+        let mut gs = Game::new(vec!["one".into()], false);
         gs.push('o');
         assert_eq!(gs.mistakes, 0);
         gs.push('o');

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn render(game: &Game, viewport: &mut Viewport, renderer: &mut Renderer<StdoutTa
             accuracy,
         } => {
             let text = format!(
-                "time: {} seconds | wpm: {} | mistakes: {} | accuracy: {:.2}% | word count: {}",
+                "time: {} seconds | wpm: {} | mistakes: {} | accuracy: {:.2}% | word count: {}\nDo you want to try again? y/n",
                 elapsed.as_secs(),
                 wpm,
                 mistakes,
@@ -176,6 +176,12 @@ fn play() -> error::Result<()> {
                     game.push(c);
                 }
                 GameState::Stopped => game.start(),
+            },
+            Event::Key(KeyEvent {
+                code: KeyCode::Enter,
+                ..
+            }) => if game.state == GameState::Stopped {
+                game.start()
             },
             Event::Key(KeyEvent {
                 code: KeyCode::Backspace,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn play() -> error::Result<()> {
     let config = Config::from_args(args())?;
     let selected_words = words(&config)?;
 
-    let mut game = Game::new(selected_words);
+    let mut game = Game::new(selected_words, config.strict);
 
     let (w, h) = term_size().expect("could not get terminal size");
     let mut viewport = Viewport::new(ScreenPos::zero(), ScreenSize::new(w, h));
@@ -167,7 +167,7 @@ fn play() -> error::Result<()> {
                 GameState::Finished { .. } => {
                     if c == 'y' {
                         let selected_words = words(&config)?;
-                        game = Game::new(selected_words);
+                        game = Game::new(selected_words, config.strict);
                     } else if c == 'n' {
                         break;
                     }


### PR DESCRIPTION
- Game can now be finished, even if there are mistakes. Game ends if space is pressed after all words are typed.
- Space is now ignored if you're at the start of a word.
- Space now skips a word, if at least one char was already typed.
- Don't add chars if input text already contains at least as many chars as needed to complete the game. So if you keep typing at the end, you don't need to delete all those "invisible" chars.
- The "-p" arg is now not needed anymore. You can just put the path at the end now.
- Added the "-s" flag, to enable strict mode. Strict mode makes it so that you can only finish the game, if you fix all the mistakes you make.