### PR TITLE
Jump back to last char before skip and implement Ctrl-w

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "toggle_cool_cow_says_type"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rand",
  "shellexpand",

--- a/src/gamestate.rs
+++ b/src/gamestate.rs
@@ -129,14 +129,14 @@ impl Game {
     }
 
     pub fn pop_word(&mut self) {
-        // pop all whitespaces
-        while let Some(' ') = self.input.chars().last() {
-            self.input.pop();
-        }
-        // pop until whitespace or no chars left
-        while let Some(_) = self.input.chars().last().filter(|&c| c != ' ') {
-            self.input.pop();
-        }
+        let to_remove = self.input.len() - self
+            .input
+            .chars()
+            .rev()
+            .skip_while(|&c| c == ' ') // remove until non-whitespace is found
+            .skip_while(|&c| c != ' ') // remove until whitespace is found
+            .count();
+        (0..to_remove).for_each(|_| drop(self.input.pop()));
     }
 
     pub fn start(&mut self) {

--- a/src/gamestate.rs
+++ b/src/gamestate.rs
@@ -118,7 +118,25 @@ impl Game {
     }
 
     pub fn pop(&mut self) {
-        self.input.pop();
+        match self.input.chars().last() {
+            Some(' ') => {
+                while let Some(' ') = self.input.chars().last() {
+                    self.input.pop();
+                }
+            }
+            _ => drop(self.input.pop()),
+        }
+    }
+
+    pub fn pop_word(&mut self) {
+        // pop all whitespaces
+        while let Some(' ') = self.input.chars().last() {
+            self.input.pop();
+        }
+        // pop until whitespace or no chars left
+        while let Some(_) = self.input.chars().last().filter(|&c| c != ' ') {
+            self.input.pop();
+        }
     }
 
     pub fn start(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::env::args;
 
-use tinybit::events::{events, Event, EventModel, KeyCode, KeyEvent};
+use tinybit::events::{events, Event, EventModel, KeyCode, KeyEvent, KeyModifiers};
 use tinybit::widgets::Text;
 use tinybit::{term_size, Color, Pixel, Renderer, ScreenPos, ScreenSize, StdoutTarget, Viewport};
 
@@ -157,6 +157,11 @@ fn play() -> error::Result<()> {
                 viewport.resize(w, h);
                 renderer.clear();
             }
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('w'),
+                modifiers,
+                ..
+            }) if modifiers == KeyModifiers::CONTROL => game.pop_word(),
             Event::Key(KeyEvent {
                 code: KeyCode::Char(c),
                 ..


### PR DESCRIPTION
- Delete all consecutive whitespaces. This way if you skip a word with space, backspace takes you back to where you were.
- Ctrl-w now deletes a whole word